### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Triangloid - A Slice of Imagnoid
+# Triangloid - A Slice of Imagnoid
 ![Triangloid Preview](img/triangloid.png)
 Triangloid is a JavaScript library that can trianglifies images and outputs as SVGs. It has been inspired and based on [Trianglify](https://github.com/qrohlf/trianglify) by [@qrohlf](https://github.com/qrohlf/).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
